### PR TITLE
Revert to old CNAME method, introduce tuning for storage env

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,25 +67,20 @@ Note: There is no "right" answer and all specifications are approximate. I haven
 
 ### Nginx related
 
-All the domain specific config is contained in the file `/etc/nginx/sites-available/xahau` but the allow list is now in the user's home folder `~/nginx_` for easier editing.
+All the domain specific config is contained in the file `/etc/nginx/sites-available/xahau` but the allowlists (yes there are two now) are in the user's home folder `~/nginx_rpc_allowlist.conf` and `nginx_wss_allowlist.conf` for easier editing and protecting form accidental deletion. Ignore the RPC one, it is a placeholder for now.
 
-Any changes to the `nginx_allowlist.conf` file MUST first be tested with `sudo nginx -t` and then reloaded with `sudo nginx -s reload`.
+Any changes to the `nginx_RPC/WSS_allowlist.conf` files MUST first be tested with `sudo nginx -t` and then reloaded with `sudo systemctl reload nginx.service`.
 
-Logs are held at `/var/log/nginx/`.
-
-Although this works best on a dedicated host with no other nginx/proxy instances, it can work behind another instance.
-You may need to adjust the setting in the main nginx.conf file to suit your environment so the allow list works correctly.
-
-For example, in nginx.conf you may need to adjust/add `set_real_ip_from 172.16.0.0/12;` for your proxy IP.
+Logs are generated at `/var/log/nginx/`.
 
 
 # Node IP Permissions
 
-The setup script adds 3 IP addresses by default to the nginx_allowlist.conf file: the detected SSH IP, the external nodes IP, and the local environment IP.
+The setup script adds 2 IP addresses by default to the nginx_RPC/WSS_allowlist.conf files: the detected SSH IP and the external nodes IP.
 
-In order to add/remove access to your node, you adjust the addresses within the `nginx_allowlist.conf` file.
+In order to add/remove access to your node, you adjust the addresses within the `nginx_wss_allowlist.conf` file. Again, ignore the RPC file.
 
-Edit the `nginx_allowlist.conf` file with your preferred editor e.g. `nano nginx_allowlist.conf`.
+Edit the `nginx_wss_allowlist.conf` file with your preferred editor e.g. `nano ~/nginx_wss_allowlist.conf`.
 
 Start every line with allow, a space, and then the IP, and end the line with a semicolon.
 
@@ -100,17 +95,9 @@ __REMOVE__ : Delete the line.
 
 THEN
 
-__TEST_AND_RELOAD__ : First `sudo nginx -t` and if successful, perform a reload with `sudo nginx -s reload`.
+__TEST_AND_RELOAD__ : First `sudo nginx -t` and if successful, perform a reload with `sudo systemctl reload nginx.service`.
 
 ---
-
-# Testing your Xahaud server
-
-This can be done simply by entering the Domain or IP into a browser.
-
-This will give you one of two results:
-  - A notice that your IP is blocked, telling you which IP to add to your nginx_allowlist.conf file.
-  - Some basic details of your node pulled by RPC.
 
 #### XAHAUD
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Note: look for `"server_state" : "full",` and your xahaud should be working as e
 
 To test the Websocket function, use the wscat command (installed by default as part of the script)
 
-Copy the following command replacing `xahl.mydomain.com` with your DNS host record from `USER_DOMAIN` in the vars file.
+Copy the following command replacing `wss.EXAMPLE.com` with your DNS CNAME record for YOUR websocket.
 
-        wscat -c wss://xahl.mydomain.com
+        wscat -c wss://wss.EXAMPLE.com
 
 A successful result is shown below with the second command verifying:
 
@@ -126,9 +126,9 @@ and enter
 
 #### RPC / API is easier to check
 
-A simple command from the command line
+A simple command from the command line (as long as you update the URL below to YOUR rpc URL!)
 
-    curl -X POST -H "Content-Type: application/json" -d '{"method":"server_info"}' http://127.0.0.1
+    curl -X POST -H "Content-Type: application/json" -d '{"method":"server_info"}' https://rpc.EXAMPLE.com
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,27 +3,28 @@ Xahau submission node installation with nginx &amp; lets encrypt TLS certificate
 
 ---
 
-This script will take the standard Xahau node install (non-docker version) and supplement it with the necessary configuration to provide a TLS secured RPC/WSS endpoint using Nginx.
+This script will take the standard Xahau node install (non-docker version) and supplement it with the necessary configuration to provide TLS secured RPC/WSS endpoints using Nginx. It also configures xahaud to auto-prune by default.
 
-This version is a major rewrite which uses a single host (A) record in place of host and two CNAME records, among other enhancements.
+NOTE! This version is back to the "old method" of using a single host (A) record and two CNAME records. You MUST edit the xahl_nodes.vars file with YOUR values AFTER you create all THREE records in DNS.
+
+[@gadget78](https://github.com/gadget78/xahl-node) is currently hosting the NEW method which uses a single host record and has some advanced status page features. I have decided to stick with my old method as an alternative option. The only major improvement with my script now is that it automatically adds the XAHL self-pruning feature so you don't unexpectedly run out of space. It also splits the allowlist for RPC and WSS in files in the home directory. As time permits, I may go back and introduce gadget's status page and toml features.
 
 ---
 
 ## Current functionality
- - Install options for Mainnet (Testnet if demand warrants)
- - Supports the use of custom variables using the `xahl_node.vars` file
+ - Install options for Mainnet (Testnet if demand warrants).
+ - Supports the use of custom variables using the `xahl_node.vars` file.
  - Detects UFW firewall & applies necessary firewall updates.
  - Installs & configures Nginx 
-   - Sets up nginx so that it splits the incoming traffic to your supplied domain to the correct 3 backends. 1.static website, 2.the websocket(wss) and 3.any rpc traffic.
-   - TL;DR; you only need ONE domain pointing to this server.
-   - Automatically detects the IPs of your ssh session, the node itself, and its local environment, and adding them to the nginx_allowlist.conf file
- - Applies NIST security best practices
+   - Currently only supports multi-domain deployment with one A record & two CNAME records (requires operator has control over the domain).
+   - Automatically detects the IPs of your ssh session and the node itself, adding both to the RPC and WSS allowlists in your home folder.
+ - Applies NIST security best practices.
  
 ---
 
 ## Update
 
-NOT FULLY TESTED. If you are updating from an older version, where the allow list was saved in `/etc/nginx/sites-available/xahau` then save your allow entries before installing.
+If you are updating from an older version, where the allow list was saved in `/etc/nginx/sites-available/xahau` then save your allow entries before installing.
 
         sudo cp /etc/nginx/sites-available/xahau ~/ # Copy to your home folder
         cat ~/xahau # view the file
@@ -36,7 +37,7 @@ NOT FULLY TESTED. If you are updating from an older version, where the allow lis
         git clone https://github.com/go140point6/xahl-node
         cd xahl-node
 
-Review xahl_node.vars and adjust default settings and user-specific variables, then run the script: 
+Review xahl_node.vars and adjust default settings and user-specific variables, then run the script (you will be prompted for sudo password): 
 
         ./setup.sh
 
@@ -44,9 +45,8 @@ Review xahl_node.vars and adjust default settings and user-specific variables, t
 
 The vars file allows you to manually update variables which helps to avoid interactive prompts during the install.
 
-- `USER_DOMAIN` - your server domain. Unlike previous versions of this script, this is a single host (A) record (i.e. xahl.EXAMPLE.com).
+- `USER_DOMAIN` - note the order in which the A & CNAME records must be entered --> THREE RECORDS, host and two CNAME!
 - `CERT_EMAIL` - email address for certificate renewals.
-- `TOML_EMIAL` - email address for the PUBLIC .toml file. Can be the same as CERT_EMAIL if desired, or something different.
 - `XAHAU_NODE_SIZE` - allows you to establish a "size" of the node.
 
 The file also controls the default packages that are installed on the node.
@@ -55,15 +55,13 @@ To adjust the default settings via this file, edit it using your preferred edito
 
         nano ~/xahl-node/xahl_node.vars
 
-there are 3 size options tiny/medium/huge, `tiny` is the default.
-- `tiny` -  less than 8G-RAM 50GB-HDD
-- `medium` - 16G-RAM 250GB-HDD
-- `huge` - 32G+RAM nolimit-HDD
+there are 4 size options tiny/small/medium/huge, `tiny` is the default.
+- `tiny` -  less than 8G RAM 50G+ storage
+- `small` - 8G+ RAM 100G+ storage
+- `medium` - 16G+ RAM 250G+ storage
+- `huge` - 32G+ RAM 500G+ storage
 
-There are other options available in the .vars file, i.e.:
- 
-    INSTALL_CERTBOT_SSL="false" will keep certbot from being installed and configured (script will set up xahaud for non-SSL use).
-    INSTALL_LANDINGPAGE="false" will prevent creation/updating of the landing page (i.e. if you have a custom one).
+Note: There is no "right" answer and all specifications are approximate. I haven't done extensive testing to see if there is a real difference between them for what I'm using my xahaud for (as an evernode submission node). See https://xrpl.org/docs/infrastructure/installation/capacity-planning/ for more information on this topic.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Review xahl_node.vars and adjust default settings and user-specific variables, t
 
         ./setup.sh
 
+## Uninstall
+
+Not recommended for production use, you would be better off reinstalling Ubuntu cleanly but I used this in my testing of the script so I am making it available:
+
+        ./_reset_xahl_node.sh
+
 ### Vars file _(xahl_node.vars)_
 
 The vars file allows you to manually update variables which helps to avoid interactive prompts during the install.

--- a/_reset_xahl_node.sh
+++ b/_reset_xahl_node.sh
@@ -82,7 +82,7 @@ sudo apt --purge remove fontconfig-config fonts-dejavu-core libdeflate0 \
 # Remove firewall rules
 sudo ufw delete allow $VARVAL_CHAIN_PEER/tcp
 sudo ufw delete allow 'Nginx Full'
-sudo ufw status verbose
+sudo ufw status --no-pager verbose
 
 # Remove and clean up xahaud
 echo -e $VARVAL_CHAIN_REPO
@@ -102,12 +102,11 @@ sudo rm -rfv /etc/logrotate.d/nginx
 sudo rm -rfv /etc/logrotate.d/xahau-logs
 
 # Remove and clean up certbot
-sudo certbot revoke --cert-path /etc/letsencrypt/live/$USER_DOMAIN/fullchain.pem --non-interactive
+sudo certbot revoke --cert-path /etc/letsencrypt/live/$A_RECORD/fullchain.pem --non-interactive
 sudo apt --purge remove certbot python3-certbot-nginx python3-acme python3-certbot python3-certifi \
     python3-configargparse python3-icu python3-josepy python3-parsedatetime python3-requests \
     python3-requests-toolbelt python3-rfc3339 python3-tz python3-urllib3 python3-zope.component \
     python3-zope.event python3-zope.hookable -y
-#sudo mv -v ~/default.nginx /etc/nginx/sites-available/default
 sudo rm -rfv /var/log/letsencrypt
 
 echo

--- a/_reset_xahl_node.sh
+++ b/_reset_xahl_node.sh
@@ -45,6 +45,12 @@ sudo -l > /dev/null 2>&1
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 source $SCRIPT_DIR/xahl_node.vars
 
+echo -e "${YELLOW}$USER_DNS_RECORDS${NC}"
+
+IFS=',' read -ra DOMAINS_ARRAY <<< "$USER_DNS_RECORDS"
+A_RECORD="${DOMAINS_ARRAY[0]}"
+CNAME_RECORD1="${DOMAINS_ARRAY[1]}"
+CNAME_RECORD2="${DOMAINS_ARRAY[2]}" 
 
 if [ $VARVAL_CHAIN_NAME = "mainnet" ]; then
     VARVAL_CHAIN_PEER="$XAHL_MAINNET_PEER"
@@ -82,7 +88,7 @@ sudo apt --purge remove fontconfig-config fonts-dejavu-core libdeflate0 \
 # Remove firewall rules
 sudo ufw delete allow $VARVAL_CHAIN_PEER/tcp
 sudo ufw delete allow 'Nginx Full'
-sudo ufw status --no-pager verbose
+sudo ufw status verbose
 
 # Remove and clean up xahaud
 echo -e $VARVAL_CHAIN_REPO
@@ -108,6 +114,10 @@ sudo apt --purge remove certbot python3-certbot-nginx python3-acme python3-certb
     python3-requests-toolbelt python3-rfc3339 python3-tz python3-urllib3 python3-zope.component \
     python3-zope.event python3-zope.hookable -y
 sudo rm -rfv /var/log/letsencrypt
+
+# Clean up files in home directory
+sudo rm -rfv $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
+sudo rm -rfv $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
 
 echo
 echo

--- a/_reset_xahl_node.sh
+++ b/_reset_xahl_node.sh
@@ -116,21 +116,8 @@ sudo apt --purge remove certbot python3-certbot-nginx python3-acme python3-certb
 sudo rm -rfv /var/log/letsencrypt
 
 # Clean up files in home directory
-echo -e $NGINX_RPC_ALLOWLIST
-if [ -z $NGINX_RPC_ALLOWLIST]; then
-    echo -e "NGINX_RPC_ALLOWLIST is not defined for some reason. Exiting before I nuke the home folder."
-    exit 1
-else 
-    sudo rm -rfv ~/$NGINX_RPC_ALLOWLIST
-fi
-
-echo -e $NGINX_WSS_ALLOWLIST
-if [ -z $NGINX_WSS_ALLOWLIST]; then
-    echo -e "NGINX_WSS_ALLOWLIST is not defined for some reason. Exiting before I nuke the home folder."
-    exit 1
-else 
-    sudo rm -rfv ~/$NGINX_WSS_ALLOWLIST
-fi
+sudo rm -rfv $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
+sudo rm -rfv $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
 
 echo
 echo

--- a/_reset_xahl_node.sh
+++ b/_reset_xahl_node.sh
@@ -116,8 +116,21 @@ sudo apt --purge remove certbot python3-certbot-nginx python3-acme python3-certb
 sudo rm -rfv /var/log/letsencrypt
 
 # Clean up files in home directory
-sudo rm -rfv $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
-sudo rm -rfv $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
+echo -e $NGINX_RPC_ALLOWLIST
+if [ -z $NGINX_RPC_ALLOWLIST]; then
+    echo -e "NGINX_RPC_ALLOWLIST is not defined for some reason. Exiting before I nuke the home folder."
+    exit 1
+else 
+    sudo rm -rfv ~/$NGINX_RPC_ALLOWLIST
+fi
+
+echo -e $NGINX_WSS_ALLOWLIST
+if [ -z $NGINX_WSS_ALLOWLIST]; then
+    echo -e "NGINX_WSS_ALLOWLIST is not defined for some reason. Exiting before I nuke the home folder."
+    exit 1
+else 
+    sudo rm -rfv ~/$NGINX_WSS_ALLOWLIST
+fi
 
 echo
 echo

--- a/setup.sh
+++ b/setup.sh
@@ -304,10 +304,6 @@ FUNC_CERTBOT(){
     CNAME_RECORD1="${DOMAINS_ARRAY[1]}"
     CNAME_RECORD2="${DOMAINS_ARRAY[2]}" 
 
-    # Start Nginx and enable it to start at boot
-    #sudo systemctl start nginx
-    #sudo systemctl enable nginx
-
     # Request and install a Let's Encrypt SSL/TLS certificate for Nginx
     sudo certbot --nginx  -m "$CERT_EMAIL" -n --agree-tos -d "$USER_DNS_RECORDS"
 
@@ -406,223 +402,6 @@ FUNC_ALLOWLIST_CHECK(){
 }
 
 
-FUNC_INSTALL_LANDINGPAGE(){
-    echo -e
-    echo -e "${GREEN}#########################################################################${NC}"
-    echo -e
-    echo -e "${GREEN}## ${YELLOW}Setup: Installing Landing page... ${NC}"
-    echo -e
-        
-    sudo mkdir -p /home/www
-    echo -e "Created /home/www directory for webfiles, and re-installing webpage."
-
-        TMP_FILE03=$(mktemp)
-        cat <<EOF > $TMP_FILE03
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Xahau Node</title>
-</head>
-<style>
-    body {
-        background-color: #121212;
-        color: #ffffff;
-        font-family: Arial, sans-serif;
-        padding: 20px;
-        margin: 2;
-        text-align: center;
-    }
-
-    h1 {
-        font-size: 28px;
-        margin-bottom: 20px;
-        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-    }
-
-    .container {
-        max-width: 300px;
-        margin: 0 auto;
-        margin-bottom: 20px;
-        padding: 20px;
-        border: 2px solid #ffffff;
-        border-radius: 10px;
-        text-align: left; /* Align content to the left */
-    }
-
-    #serverInfo {
-        background-color: #1a1a1a;
-        padding: 20px;
-        border-radius: 10px;
-        margin-top: 10px;
-        margin: 0 auto;
-        max-width: 600px;
-        color: #ffffff;
-        font-family: Arial, sans-serif;
-        font-size: 14px;
-        white-space: pre-wrap;
-        overflow: auto; /* Add scrollbars if needed */
-        text-align: left; /* Align content to the left */
-    }
-</style>
-<body>
-    <h1>Xahau Node Landing Page</h1>
-
-    <div class="container">
-        <h1>Server Info</h1>
-        <p>Status: <span id="status"></span></p>
-        <p>Build Version: <span id="buildVersion"></span></p>
-        <p>Current Ledger: <span id="currentLedger"></span></p>
-        <p>Complete Ledgers: <span id="completeLedgers"></span></p>
-        <p>Last Refresh: <span id="time"></span></p>
-    </div>
-
-    <pre id="serverInfo"></pre>
-
-    <script>
-        const dataToSend = {"method":"server_info"};
-        fetch('https://$A_RECORD', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(dataToSend)
-        })
-            .then(response => {
-                return response.json();
-            })
-            .then(serverInfo => {
-                const formattedJson = JSON.stringify(serverInfo, null, 2);
-                document.getElementById('serverInfo').textContent = formattedJson;
-                document.getElementById('status').textContent = serverInfo.result.status;
-                document.getElementById('buildVersion').textContent = serverInfo.result.info.build_version;
-                document.getElementById('currentLedger').textContent = serverInfo.result.info.validated_ledger.seq;
-                document.getElementById('completeLedgers').textContent = serverInfo.result.info.complete_ledgers;
-                document.getElementById('time').textContent = serverInfo.result.info.time;
-            })
-            .catch(error => {
-                console.error('Error fetching server info:', error);
-                document.getElementById('status').textContent = "failed, server could be down";
-                document.getElementById('status').style.color = "red";
-            });
-    </script>
-</body>
-</html>
-EOF
-sudo sh -c "cat $TMP_FILE03 > /home/www/index.html"
-
-        sudo mkdir -p /home/www/error
-        echo "created /home/www/error directory for blocked page, re-installing webpage"
-        TMP_FILE04=$(mktemp)
-        cat <<EOF > $TMP_FILE04
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Xahau Node</title>
-</head>
-<style>
-body {
-    background-color: #121212;
-    color: #ffffff;
-    font-family: Arial, sans-serif;
-    padding: 20px;
-    margin: 2;
-    text-align: center;
-}
-
-h1 {
-    font-size: 28px;
-    margin-bottom: 20px;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-}
-
-.container {
-    max-width: 300px;
-    margin: 0 auto;
-    margin-bottom: 20px;
-    padding: 20px;
-    border: 2px solid #ffffff;
-    border-radius: 10px;
-    text-align: left; /* Align content to the left */
-}
-
-#serverInfo {
-    background-color: #1a1a1a;
-    padding: 20px;
-    border-radius: 10px;
-    margin-top: 10px;
-    margin: 0 auto;
-    max-width: 600px;
-    color: #ffffff;
-    font-family: Arial, sans-serif;
-    font-size: 14px;
-    white-space: pre-wrap;
-    overflow: auto; /* Add scrollbars if needed */
-    text-align: left; /* Align content to the left */
-}
-</style>
-
-<body>
-    <h1>Xahau Node Landing Page</h1>
-
-    <div class="container">
-        <h1>Server Info</h1>
-        <p><span style="color: red;">THIS SERVER IS BLOCKING YOUR IP</span></p>
-        <p>YourIP: <span id="realip"></p>
-        <p>X-Real-IP: <span id="xrealip"></p>
-        <p>-</p>
-
-        <p>Status: </p>
-        <p>Build Version: </p>
-        <p>Current Ledger: </p>
-        <p>Complete Ledgers: </span></p>
-        <p>Last Refresh: </span></p>
-    </div>
-
-    <pre id="serverInfo"></pre>
-
-    <script>
-        const dataToSend = {"method":"server_info"};
-        fetch('https://$A_RECORD', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(dataToSend)
-        })
-        .then(response => {
-            const xRealIp = response.headers.get('X-Real-IP');
-            document.getElementById('xrealip').textContent = xRealIp;
-        })
-        .catch(error => {
-            console.error('Error fetching X-Real-IP:', error);
-            document.getElementById('xrealip').textContent = "unknown";
-        });
-
-        fetch('https://ipinfo.io/ip')
-        .then(response => response.text())
-        .then(ipinfo => {
-            document.getElementById('realip').textContent = ipinfo;
-        })
-        .catch(error => {
-            console.error('Error fetching client IP:', error);
-            document.getElementById('realip').textContent = "unknown";
-        });
-    </script>
-
-</body>
-</html>
-EOF
-    sudo sh -c "cat $TMP_FILE04 > /home/www/error/custom_403.html"
-    
-    echo
-    sleep 2s
-}
-
-
 FUNC_NODE_DEPLOY(){
     
     echo -e "${GREEN}#########################################################################${NC}"
@@ -702,9 +481,6 @@ FUNC_NODE_DEPLOY(){
 
     FUNC_CERTBOT;
     #FUNC_EXIT;
-
-    #setup and install the landing page,
-    FUNC_INSTALL_LANDINGPAGE;
 
     # Create a new Nginx configuration file with the user-provided variables....
     echo
@@ -871,7 +647,7 @@ EOF
     echo -e "${GREEN}#########################################################################${NC}"
     echo -e "Your Xahau Node should now be up and running."
     echo -e
-    echo -e "Externally: Websocket ${BYELLOW}wss://$CNAME2${NC} or RPC/API ${BYELLOW}https://$CNAME1${NC}"
+    echo -e "Externally: Websocket ${BYELLOW}wss://$CNAME_RECORD2${NC} or RPC/API ${BYELLOW}https://$CNAME_RECORD1${NC}"
     echo -e
     echo -e "Use file ${BYELLOW}$SCRIPT_DIR/$NGINX_WSS_ALLOWLIST${NC} to add/remove IP addresses that access your node using websockets."
     echo -e "Once file is edited and saved, TEST it with ${BYELLOW}'sudo nginx -t'${NC} before running the command ${BYELLOW}'sudo systemctl reload nginx.service'${NC} to apply new settings."

--- a/setup.sh
+++ b/setup.sh
@@ -99,7 +99,7 @@ FUNC_CHECK_VARS(){
         echo -e "${YELLOW}$ERROR4${NC}"
         echo -e
     fi
-    if [ -n "$ERROR1" || -n "$ERROR2" || -n "$ERROR3" || -n "$ERROR4" ]; then
+    if [ -n "$ERROR1" ] || [ -n "$ERROR2" ] || [ -n "$ERROR3" ] || [ -n "$ERROR4" ]; then
         echo -e ${RED}You must fix the errors above before running this script.${NC}
         FUNC_EXIT_ERROR
     else

--- a/setup.sh
+++ b/setup.sh
@@ -371,23 +371,23 @@ FUNC_ALLOWLIST_CHECK(){
     echo "Adding default IPs to both rpc and wss files..."
     echo
     
-    if [ -f "~/$NGINX_RPC_ALLOWLIST" ]; then
+    if [ -f "$SCRIPT_DIR/$NGINX_RPC_ALLOWLIST" ]; then
         echo -e "The `$NGINX_RPC_ALLOWLIST` file already exsits at this location, no default changes..."
     else
-        echo "allow $SRC_IP; # Detected IP of the SSH session" >> ~/$NGINX_RPC_ALLOWLIST
+        echo "allow $SRC_IP; # Detected IP of the SSH session" >> $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
         echo -e "added IP $SRC_IP; # Detected IP of the SSH session"
       
-        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> ~/$NGINX_RPC_ALLOWLIST
+        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
         echo -e "added IP $NODE_IP; # ExternalIP of the Node itself"
     fi
 
-    if [ -f "~/$NGINX_WSS_ALLOWLIST" ]; then
+    if [ -f "$SCRIPT_DIR/$NGINX_WSS_ALLOWLIST" ]; then
         echo -e "The `$NGINX_WSS_ALLOWLIST` file already exsits at this location, no default changes..."
     else
-        echo "allow $SRC_IP; # Detected IP of the SSH session" >> ~/$NGINX_WSS_ALLOWLIST
+        echo "allow $SRC_IP; # Detected IP of the SSH session" >> $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
         echo -e "added IP $SRC_IP; # Detected IP of the SSH session"
 
-        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> ~/$NGINX_WSS_ALLOWLIST
+        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
         echo -e "added IP $NODE_IP; # ExternalIP of the Node itself"
     fi
 
@@ -536,7 +536,7 @@ server {
     
     location / {
         try_files \$uri \$uri/ =404;
-        include ~/$NGINX_RPC_ALLOWLIST;
+        include $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST;
         deny all;
 
         proxy_pass http://localhost:$VARVAL_CHAIN_RPC;
@@ -588,7 +588,7 @@ server {
     
     location / {
         try_files \$uri \$uri/ =404;
-        include ~/$NGINX_WSS_ALLOWLIST;
+        include $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST;
         deny all;
 
         proxy_pass http://localhost:$VARVAL_CHAIN_WSS;
@@ -644,10 +644,10 @@ EOF
     echo -e
     echo -e "Externally: Websocket ${BYELLOW}wss://$CNAME_RECORD2${NC} or RPC/API ${BYELLOW}https://$CNAME_RECORD1${NC}"
     echo -e
-    echo -e "Use file ${BYELLOW}~/$NGINX_WSS_ALLOWLIST${NC} to add/remove IP addresses that access your node using websockets."
+    echo -e "Use file ${BYELLOW}$SCRIPT_DIR/$NGINX_WSS_ALLOWLIST${NC} to add/remove IP addresses that access your node using websockets."
     echo -e "Once file is edited and saved, TEST it with ${BYELLOW}'sudo nginx -t'${NC} before running the command ${BYELLOW}'sudo systemctl reload nginx.service'${NC} to apply new settings."
     echo -e
-    echo -e "Ingore file ${BYELLOW}~/$NGINX_RPC_ALLOWLIST${NC}. It was generated only as a placeholder for future potential use."
+    echo -e "Ingore file ${BYELLOW}$SCRIPT_DIR/$NGINX_RPC_ALLOWLIST${NC}. It was generated only as a placeholder for future potential use."
     echo -e
     echo -e "Use command ${BYELLOW}xahaud server_info${NC} to get info direct from the xahaud server."
     echo -e

--- a/setup.sh
+++ b/setup.sh
@@ -528,12 +528,6 @@ server {
     add_header Host \$host;
     add_header X-Real-IP \$remote_addr;
 
-    error_page 403 /custom_403.html;
-    location /custom_403.html {
-        root /home/www/error;
-        internal;
-    }
-    
     location / {
         try_files \$uri \$uri/ =404;
         include $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST;
@@ -584,7 +578,6 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Host \$host;
     add_header X-Real-IP \$remote_addr;
-    }
     
     location / {
         try_files \$uri \$uri/ =404;

--- a/setup.sh
+++ b/setup.sh
@@ -195,16 +195,16 @@ FUNC_CLONE_NODE_SETUP(){
     echo -e "Updating node size in .cfg file ..."
     echo
 
-    if [ "$XAHAU_NODE_SIZE" === "tiny" ]; then
+    if [ "$XAHAU_NODE_SIZE" = "tiny" ]; then
         XAHAU_LEDGER_HISTORY=$TINY_LEDGER_HISTORY
         XAHAU_ONLINE_DELETE=$TINY_LEDGER_DELETE
-    elif [ "$XAHAU_NODE_SIZE" === "small" ]; then
+    elif [ "$XAHAU_NODE_SIZE" = "small" ]; then
         XAHAU_LEDGER_HISTORY=$SMALL_LEDGER_HISTORY
         XAHAU_ONLINE_DELETE=$SMALL_LEDGER_DELETE
-    elif [ "$XAHAU_NODE_SIZE" === "medium" ]; then
+    elif [ "$XAHAU_NODE_SIZE" = "medium" ]; then
         XAHAU_LEDGER_HISTORY=$MEDIUM_LEDGER_HISTORY
         XAHAU_ONLINE_DELETE=$MEDIUM_LEDGER_DELETE
-    elif [ "$XAHAU_NODE_SIZE" === "huge" ]; then
+    elif [ "$XAHAU_NODE_SIZE" = "huge" ]; then
         XAHAU_LEDGER_HISTORY=$HUGE_LEDGER_HISTORY
         XAHAU_ONLINE_DELETE=$HUGE_LEDGER_DELETE
     fi
@@ -281,7 +281,7 @@ FUNC_SETUP_UFW_PORTS(){
     echo -e "current Xahau Node port number detected as: ${BYELLOW}$VARVAL_CHAIN_PEER${NC}"
     sudo ufw allow $CPORT/tcp
     sudo ufw allow $VARVAL_CHAIN_PEER/tcp
-    sudo ufw status --no-pager verbose
+    sudo ufw status verbose
     sleep 2s
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -371,29 +371,29 @@ FUNC_ALLOWLIST_CHECK(){
     echo "Adding default IPs to both rpc and wss files..."
     echo
     
-    if [ -f "$SCRIPT_DIR/$NGINX_RPC_ALLOWLIST" ]; then
+    if [ -f "~/$NGINX_RPC_ALLOWLIST" ]; then
         echo -e "The `$NGINX_RPC_ALLOWLIST` file already exsits at this location, no default changes..."
     else
-        echo "allow $SRC_IP; # Detected IP of the SSH session" >> $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
+        echo "allow $SRC_IP; # Detected IP of the SSH session" >> ~/$NGINX_RPC_ALLOWLIST
         echo -e "added IP $SRC_IP; # Detected IP of the SSH session"
       
-        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
+        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> ~/$NGINX_RPC_ALLOWLIST
         echo -e "added IP $NODE_IP; # ExternalIP of the Node itself"
     fi
 
-    if [ -f "$SCRIPT_DIR/$NGINX_WSS_ALLOWLIST" ]; then
+    if [ -f "~/$NGINX_WSS_ALLOWLIST" ]; then
         echo -e "The `$NGINX_WSS_ALLOWLIST` file already exsits at this location, no default changes..."
     else
-        echo "allow $SRC_IP; # Detected IP of the SSH session" >> $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
+        echo "allow $SRC_IP; # Detected IP of the SSH session" >> ~/$NGINX_WSS_ALLOWLIST
         echo -e "added IP $SRC_IP; # Detected IP of the SSH session"
 
-        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
+        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> ~/$NGINX_WSS_ALLOWLIST
         echo -e "added IP $NODE_IP; # ExternalIP of the Node itself"
     fi
 
     echo
     echo
-    echo -e "${BLUE}ATTENTION! You now have two files in $SCRIPT_DIR called $NGINX_RPC_ALLOWLIST and $NGINX_WSS_ALLOWLIST.${NC}"
+    echo -e "${BLUE}ATTENTION! You now have two files in your home folder called $NGINX_RPC_ALLOWLIST and $NGINX_WSS_ALLOWLIST.${NC}"
     echo -e
     echo -e "Now edit the $NGINX_WSS_ALLOWLIST and ADD EACH IP address of your systems that want to access your websockets."
     echo -e "You can ignore $NGINX_RPC_ALLOWLIST for now, that is in place for potential future use."
@@ -536,7 +536,7 @@ server {
     
     location / {
         try_files \$uri \$uri/ =404;
-        include $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST;
+        include ~/$NGINX_RPC_ALLOWLIST;
         deny all;
 
         proxy_pass http://localhost:$VARVAL_CHAIN_RPC;
@@ -584,16 +584,11 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Host \$host;
     add_header X-Real-IP \$remote_addr;
-
-    error_page 403 /custom_403.html;
-    location /custom_403.html {
-        root /home/www/error;
-        internal;
     }
     
     location / {
         try_files \$uri \$uri/ =404;
-        include $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST;
+        include ~/$NGINX_WSS_ALLOWLIST;
         deny all;
 
         proxy_pass http://localhost:$VARVAL_CHAIN_WSS;
@@ -649,10 +644,10 @@ EOF
     echo -e
     echo -e "Externally: Websocket ${BYELLOW}wss://$CNAME_RECORD2${NC} or RPC/API ${BYELLOW}https://$CNAME_RECORD1${NC}"
     echo -e
-    echo -e "Use file ${BYELLOW}$SCRIPT_DIR/$NGINX_WSS_ALLOWLIST${NC} to add/remove IP addresses that access your node using websockets."
+    echo -e "Use file ${BYELLOW}~/$NGINX_WSS_ALLOWLIST${NC} to add/remove IP addresses that access your node using websockets."
     echo -e "Once file is edited and saved, TEST it with ${BYELLOW}'sudo nginx -t'${NC} before running the command ${BYELLOW}'sudo systemctl reload nginx.service'${NC} to apply new settings."
     echo -e
-    echo -e "Ingore file ${BYELLOW}$SCRIPT_DIR/$NGINX_RPC_ALLOWLIST${NC}. It was generated only as a placeholder for future potential use."
+    echo -e "Ingore file ${BYELLOW}~/$NGINX_RPC_ALLOWLIST${NC}. It was generated only as a placeholder for future potential use."
     echo -e
     echo -e "Use command ${BYELLOW}xahaud server_info${NC} to get info direct from the xahaud server."
     echo -e

--- a/setup.sh
+++ b/setup.sh
@@ -734,8 +734,8 @@ server {
     server_name $CNAME_RECORD1;
 
     # SSL certificate paths
-    ssl_certificate /etc/letsencrypt/live/$$A_RECORD/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$$A_RECORD/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$A_RECORD/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$A_RECORD/privkey.pem;
 
     # Other SSL settings
     ssl_protocols TLSv1.3 TLSv1.2;
@@ -791,8 +791,8 @@ server {
     server_name $CNAME_RECORD2;
 
     # SSL certificate paths
-    ssl_certificate /etc/letsencrypt/live/$$A_RECORD/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$$A_RECORD/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$A_RECORD/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$A_RECORD/privkey.pem;
 
     # Other SSL settings
     ssl_protocols TLSv1.3 TLSv1.2;
@@ -832,7 +832,7 @@ server {
 
         # These three are critical to getting websockets to work
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection "upgrade";
     }
 

--- a/setup.sh
+++ b/setup.sh
@@ -67,7 +67,7 @@ source $SCRIPT_DIR/xahl_node.vars
 FDATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 
-FUNC_CHECK_VARS() {
+FUNC_CHECK_VARS(){
     echo -e "${GREEN}#########################################################################${NC}"
     echo
     echo -e "${GREEN}## Check for properly configured xahl_node.vars file...${NC}"
@@ -86,22 +86,26 @@ FUNC_CHECK_VARS() {
     if [ -n "$ERROR1" ]; then
         echo -e "${YELLOW}$ERROR1${NC}"
         echo -e
+    fi
     if [ -n "$ERROR2" ]; then
         echo -e "${YELLOW}$ERROR2${NC}"
         echo -e
+    fi
     if [ -n "$ERROR3" ]; then
         echo -e "${YELLOW}$ERROR3${NC}"
         echo -e
+    fi
     if [ -n "$ERROR4" ]; then
         echo -e "${YELLOW}$ERROR4${NC}"
         echo -e
-
+    fi
     if [ -n "$ERROR1" || -n "$ERROR2" || -n "$ERROR3" || -n "$ERROR4" ]; then
         echo -e ${RED}You must fix the errors above before running this script.${NC}
         FUNC_EXIT_ERROR
     else
         echo -e "${GREEN}xahl-node.vars appears to be correctly configured, continuing...${NC}"
         sleep 2
+    fi
 }
 
 
@@ -239,8 +243,10 @@ FUNC_SETUP_UFW(){
             FUNC_UFW_LOGGING
         else
             echo -e "UFW is installed but not running. This is ${RED}NOT GOOD${NC} unless you have other protection in place. Skipping UFW configuration..."
+        fi
     else
         echo -e "UFW is not installed. This is ${RED}NOT GOOD${NC} unless you have other protection in place. Skipping UFW configuration..."
+    fi
 }
 
 FUNC_UFW_LOGGING(){
@@ -288,9 +294,9 @@ FUNC_CERTBOT(){
     # Install Let's Encrypt Certbot
     sudo apt install certbot python3-certbot-nginx -y
 
-    echo -e "${YELLOW}$USER_DOMAINS${NC}"
+    echo -e "${YELLOW}$USER_DNS_RECORDS${NC}"
 
-    IFS=',' read -ra DOMAINS_ARRAY <<< "$USER_DOMAINS"
+    IFS=',' read -ra DOMAINS_ARRAY <<< "$USER_DNS_RECORDS"
     A_RECORD="${DOMAINS_ARRAY[0]}"
     CNAME_RECORD1="${DOMAINS_ARRAY[1]}"
     CNAME_RECORD2="${DOMAINS_ARRAY[2]}" 
@@ -300,7 +306,7 @@ FUNC_CERTBOT(){
     #sudo systemctl enable nginx
 
     # Request and install a Let's Encrypt SSL/TLS certificate for Nginx
-    sudo certbot --nginx  -m "$CERT_EMAIL" -n --agree-tos -d "$USER_DOMAINS"
+    sudo certbot --nginx  -m "$CERT_EMAIL" -n --agree-tos -d "$USER_DNS_RECORDS"
 
     echo
     echo -e "${GREEN}#########################################################################${NC}"

--- a/setup.sh
+++ b/setup.sh
@@ -636,7 +636,7 @@ FUNC_NODE_DEPLOY(){
 
     # installs updates, and default packages listed in vars file
     FUNC_CHECK_VARS;
-    FUNC_EXIT;
+    #FUNC_EXIT;
 
     FUNC_PKG_CHECK;
     #FUNC_EXIT;
@@ -898,6 +898,8 @@ SIGINT_EXIT(){
 
 FUNC_EXIT(){
     # remove the sudo timeout for USER_ID.
+    echo -e
+    echo -e "${GREEN}Performing clean-up:${NC}"
     sudo sh -c "rm -fv /etc/sudoers.d/$TMP_FILENAME01"
     bash ~/.profile
     sudo -u $USER_ID sh -c 'bash ~/.profile'

--- a/setup.sh
+++ b/setup.sh
@@ -73,14 +73,14 @@ FUNC_CHECK_VARS(){
     echo -e "${GREEN}## Check for properly configured xahl_node.vars file...${NC}"
     echo     
 
-    if [ "$USER_DNS_RECORDS" === "xahl.EXAMPLE.com,rpc.EXAMPLE.com,wss.EXAMPLE.com" ]; then
-        ERROR1 = "USER_DNS_RECORDS appears to be using sample data in xahl_node.vars."
-    elif [ "CERT_EMAIL" === "yourRealEmailAddress@EXAMPLE.com" ]; then
-        ERROR2 = "CERT_EMAIL appears to be using sample data in xahl_node.vars."
-    elif [ "$XAHAU_NODE_SIZE" !== "tiny" ] || [ "$XAHAU_NODE_SIZE" !== "small" ] || [ "$XAHAU_NODE_SIZE" !== "medium" ] || [ "$XAHAU_NODE_SIZE" !== "huge" ]; then
-        ERROR3 = "XAHAU_NODE_SIZE appears to be using some value that is not valid in xahl_node.vars."
-    elif [ "$VARVAL_CHAIN_NAME" !== 'mainnet' ] || [ "$VARVAL_CHAIN_NAME" !== 'testnet' ]; then
-        ERROR4 = "VARVAL_CHAIN_NAME appears to be set incorrectly, valid options are mainnet or testnet ONLY."
+    if [ "$USER_DNS_RECORDS" = "xahl.EXAMPLE.com,rpc.EXAMPLE.com,wss.EXAMPLE.com" ]; then
+        ERROR1="USER_DNS_RECORDS appears to be using sample data in xahl_node.vars."
+    elif [ "$CERT_EMAIL" = "yourRealEmailAddress@EXAMPLE.com" ]; then
+        ERROR2="CERT_EMAIL appears to be using sample data in xahl_node.vars."
+    elif [ "$XAHAU_NODE_SIZE" != "tiny" ] && [ "$XAHAU_NODE_SIZE" != "small" ] && [ "$XAHAU_NODE_SIZE" != "medium" ] && [ "$XAHAU_NODE_SIZE" != "huge" ]; then
+        ERROR3="XAHAU_NODE_SIZE appears to be using some value that is not valid in xahl_node.vars."
+    elif [ "$VARVAL_CHAIN_NAME" != 'mainnet' ] && [ "$VARVAL_CHAIN_NAME" != 'testnet' ]; then
+        ERROR4="VARVAL_CHAIN_NAME appears to be set incorrectly, valid options are mainnet or testnet ONLY."
     fi
 
     if [ -n "$ERROR1" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -67,40 +67,60 @@ source $SCRIPT_DIR/xahl_node.vars
 FDATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 
-FUNC_PKG_CHECK(){
-    echo
+FUNC_CHECK_VARS() {
     echo -e "${GREEN}#########################################################################${NC}"
     echo
-    echo -e "${GREEN}## ${YELLOW}Check/install necessary updates, ando packages... ${NC}"
+    echo -e "${GREEN}## Check for properly configured xahl_node.vars file...${NC}"
     echo     
 
-    # Update and upgrade the system
-    if [ -z "$INSTALL_UPDATES" ]; then
-        read -p "Do you want to check, and install OS updates? Enter true or false: " INSTALL_UPDATES
-        sed -i "s/^INSTALL_UPDATES=.*/INSTALL_UPDATES=\"$INSTALL_UPDATES\"/" $SCRIPT_DIR/xahl_node.vars
-    fi
-    if [ "$INSTALL_UPDATES" == "true" ]; then
-      sudo apt update -y && sudo apt upgrade -y
+    if [ "$USER_DNS_RECORDS" === "xahl.EXAMPLE.com,rpc.EXAMPLE.com,wss.EXAMPLE.com" ]; then
+        ERROR1 = "USER_DNS_RECORDS appears to be using sample data in xahl_node.vars."
+    elif [ "CERT_EMAIL" === "yourRealEmailAddress@EXAMPLE.com" ]; then
+        ERROR2 = "CERT_EMAIL appears to be using sample data in xahl_node.vars."
+    elif [ "$XAHAU_NODE_SIZE" !== "tiny" ] || [ "$XAHAU_NODE_SIZE" !== "small" ] || [ "$XAHAU_NODE_SIZE" !== "medium" ] || [ "$XAHAU_NODE_SIZE" !== "huge" ]; then
+        ERROR3 = "XAHAU_NODE_SIZE appears to be using some value that is not valid in xahl_node.vars."
+    elif [ "$VARVAL_CHAIN_NAME" !== 'mainnet' ] || [ "$VARVAL_CHAIN_NAME" !== 'testnet' ]; then
+        ERROR4 = "VARVAL_CHAIN_NAME appears to be set incorrectly, valid options are mainnet or testnet ONLY."
     fi
 
-    echo -e "${GREEN}## ${YELLOW}Cycle through packages in vars file, and install... ${NC}"
+    if [ -n "$ERROR1" ]; then
+        echo -e "${YELLOW}$ERROR1${NC}"
+        echo -e
+    if [ -n "$ERROR2" ]; then
+        echo -e "${YELLOW}$ERROR2${NC}"
+        echo -e
+    if [ -n "$ERROR3" ]; then
+        echo -e "${YELLOW}$ERROR3${NC}"
+        echo -e
+    if [ -n "$ERROR4" ]; then
+        echo -e "${YELLOW}$ERROR4${NC}"
+        echo -e
+
+    if [ -n "$ERROR1" || -n "$ERROR2" || -n "$ERROR3" || -n "$ERROR4" ]; then
+        echo -e ${RED}You must fix the errors above before running this script.${NC}
+        FUNC_EXIT_ERROR
+    else
+        echo -e "${GREEN}xahl-node.vars appears to be correctly configured, continuing...${NC}"
+        sleep 2
+}
+
+
+FUNC_PKG_CHECK(){
+
+    echo -e "${GREEN}#########################################################################${NC}"
+    echo
+    echo -e "${GREEN}## CHECK NECESSARY PACKAGES HAVE BEEN INSTALLED...${NC}"
     echo     
-    # Cycle through packages in vars file, and install
+
     for i in "${SYS_PACKAGES[@]}"
     do
         hash $i &> /dev/null
         if [ $? -eq 1 ]; then
-            echo >&2 "package "$i" not found. installing...."
-            sudo apt install -y "$i"
-        else
-            echo "packages "$i" exist, proceeding to next...."
+           echo >&2 "package "$i" not found. installing...."
+           sudo apt install -y "$i"
         fi
+        echo "packages "$i" exist. proceeding...."
     done
-    echo -e "${GREEN}## ALL PACKAGES INSTALLED.${NC}"
-    echo 
-    echo -e "${GREEN}#########################################################################${NC}"
-    echo
-    sleep 2s
 }
 
 
@@ -168,74 +188,28 @@ FUNC_CLONE_NODE_SETUP(){
     echo -e "Updating node size in .cfg file ..."
     echo
 
-    # Prompt for Chain if not provided as a variable
-    if [ -z "$VARVAL_CHAIN_NAME" ]; then
-
-        while true; do
-         read -p "Enter which chain your node is deployed on (e.g. mainnet or testnet): " _input
-
-            case $_input in
-                testnet )
-                    VARVAL_CHAIN_NAME="testnet"
-                    break
-                    ;;
-                mainnet )
-                    VARVAL_CHAIN_NAME="mainnet"
-                    break
-                    ;;
-                * ) echo "Please answer a valid option.";;
-            esac
-        done
-
+    if [ "$XAHAU_NODE_SIZE" === "tiny" ]; then
+        XAHAU_LEDGER_HISTORY=$TINY_LEDGER_HISTORY
+        XAHAU_ONLINE_DELETE=$TINY_LEDGER_DELETE
+    elif [ "$XAHAU_NODE_SIZE" === "small" ]; then
+        XAHAU_LEDGER_HISTORY=$SMALL_LEDGER_HISTORY
+        XAHAU_ONLINE_DELETE=$SMALL_LEDGER_DELETE
+    elif [ "$XAHAU_NODE_SIZE" === "medium" ]; then
+        XAHAU_LEDGER_HISTORY=$MEDIUM_LEDGER_HISTORY
+        XAHAU_ONLINE_DELETE=$MEDIUM_LEDGER_DELETE
+    elif [ "$XAHAU_NODE_SIZE" === "huge" ]; then
+        XAHAU_LEDGER_HISTORY=$HUGE_LEDGER_HISTORY
+        XAHAU_ONLINE_DELETE=$HUGE_LEDGER_DELETE
     fi
 
-    if [ "$XAHAU_NODE_SIZE" != "tiny" ] && [ "$XAHAU_NODE_SIZE" != "medium" ] && [ "$XAHAU_NODE_SIZE" != "huge" ]; then
-        echo -e "${BLUE}XAHAU_NODE_SIZE= not set in $SCRIPT_DIR/.env file."
-        echo "Please choose an option:"
-        echo "1. tiny = less than 8G-RAM, 50GB-HDD"
-        echo "2. medium = 8-16G RAM, 250GBB-HDD"
-        echo "3. huge = 32G+ RAM, no limit on HDD ${NC}"
-        read -p "Enter your choice [1-3]: " choice
-        
-            case $choice in
-                1) 
-                    XAHAU_NODE_SIZE="tiny"
-                    ;;
-                2) 
-                    XAHAU_NODE_SIZE="medium"
-                    ;;
-                3) 
-                    XAHAU_NODE_SIZE="huge"
-                    ;;
-                *) 
-                    echo "Invalid option. Exiting."
-                    FUNC_EXIT
-                    ;;
-            esac
-            sudo sed -i "s/^XAHAU_NODE_SIZE=.*/XAHAU_NODE_SIZE=\"$XAHAU_NODE_SIZE\"/" $SCRIPT_DIR/xahl_node.vars
-        fi
-    
-        if [ "$XAHAU_NODE_SIZE" == "tiny" ]; then
-            XAHAU_LEDGER_HISTORY=$TINY_LEDGER_HISTORY
-            XAHAU_ONLINE_DELETE=$TINY_LEDGER_DELETE
-        fi
-        if [ "$XAHAU_NODE_SIZE" == "medium" ]; then
-            XAHAU_LEDGER_HISTORY=$MEDIUM_LEDGER_HISTORY
-            XAHAU_ONLINE_DELETE=$MEDIUM_LEDGER_DELETE
-        fi
-        if [ "$XAHAU_NODE_SIZE" == "huge" ]; then
-            XAHAU_LEDGER_HISTORY="full"
-            XAHAU_ONLINE_DELETE=""
-        fi
-    echo "."
+    echo ".setting node_size."
     sudo sed -i "/^\[node_size\]/!b;n;c$XAHAU_NODE_SIZE" /opt/xahaud/etc/xahaud.cfg
-    echo ".."
+    echo "..setting ledger_history.."
     sudo sed -i -e 's/^#\{0,1\}\(\[ledger_history\]\)/\1/; /^\[ledger_history\]/ { n; s/.*/'"$XAHAU_LEDGER_HISTORY"'/; }' /opt/xahaud/etc/xahaud.cfg   
-    echo "..."
+    echo "...setting online_delete..."
     grep -q 'online_delete' /opt/xahaud/etc/xahaud.cfg || sudo sed -i '/^online_delete.*/!{ /\[node_db\]/ s/$/\nonline_delete='"$XAHAU_ONLINE_DELETE"'/ }' /opt/xahaud/etc/xahaud.cfg
-    echo "...."
     sudo sed -i "s/online_delete=.*/online_delete=$XAHAU_ONLINE_DELETE/" /opt/xahaud/etc/xahaud.cfg
-    echo "....."
+    echo ".....done...."
 
     # Restart xahau for changes to take effect
     sudo systemctl restart xahaud.service
@@ -248,6 +222,39 @@ FUNC_CLONE_NODE_SETUP(){
     sleep 4s
 }
 
+
+FUNC_SETUP_UFW(){
+
+    echo 
+    echo 
+    echo -e "${GREEN}#########################################################################${NC}" 
+    echo -e
+    echo -e "${GREEN}## ${YELLOW}Setup: UFW Firewall...${NC}"
+    echo -e
+
+    # Check if ufw is installed and just skip UFW stuff if not
+    if sudo systemctl list-unit-files --type=service | grep -q 'ufw.service'; then
+        if sudo systemctl is-active --quiet ufw.service; then
+            FUNC_SETUP_UFW_PORTS
+            FUNC_UFW_LOGGING
+        else
+            echo -e "UFW is installed but not running. This is ${RED}NOT GOOD${NC} unless you have other protection in place. Skipping UFW configuration..."
+    else
+        echo -e "UFW is not installed. This is ${RED}NOT GOOD${NC} unless you have other protection in place. Skipping UFW configuration..."
+}
+
+FUNC_UFW_LOGGING(){
+    echo -e
+    echo -e
+    echo -e "${GREEN}#########################################################################${NC}"
+    echo -e
+    echo -e "${GREEN}## ${YELLOW}Setup: Change UFW logging to ufw.log only${NC}"
+    echo -e
+    # source: https://handyman.dulare.com/ufw-block-messages-in-syslog-how-to-get-rid-of-them/
+    sudo sed -i -e 's/\#& stop/\& stop/g' /etc/rsyslog.d/20-ufw.conf
+    sudo cat /etc/rsyslog.d/20-ufw.conf | grep '& stop'
+    echo -e "Logging changed to ufw.log only if you see & stop as the output above."
+}
 
 
 FUNC_SETUP_UFW_PORTS(){
@@ -262,40 +269,12 @@ FUNC_SETUP_UFW_PORTS(){
     # Get current SSH and xahau node port number, and unblock them
     CPORT=$(sudo ss -tlpn | grep sshd | awk '{print$4}' | cut -d ':' -f 2 -s)
     echo -e "current SSH port number detected as: ${BYELLOW}$CPORT${NC}"
-    echo -e "current Xahau Node port number detected as: ${BYELLOW}$CPORT${NC}"
+    echo -e "current Xahau Node port number detected as: ${BYELLOW}$VARVAL_CHAIN_PEER${NC}"
     sudo ufw allow $CPORT/tcp
     sudo ufw allow $VARVAL_CHAIN_PEER/tcp
-    sudo ufw status verbose
+    sudo ufw status --no-pager verbose
     sleep 2s
 }
-
-
-FUNC_ENABLE_UFW(){
-
-    echo 
-    echo 
-    echo -e "${GREEN}#########################################################################${NC}"
-    echo 
-    echo -e "${GREEN}## ${YELLOW}Setup: Change UFW logging to ufw.log only${NC}"
-    echo 
-    # source: https://handyman.dulare.com/ufw-block-messages-in-syslog-how-to-get-rid-of-them/
-    sudo sed -i -e 's/\#& stop/\& stop/g' /etc/rsyslog.d/20-ufw.conf
-    sudo cat /etc/rsyslog.d/20-ufw.conf | grep '& stop'
-    echo -e "Logging changed to ufw.log only."
-
-    echo 
-    echo 
-    echo -e "${GREEN}#########################################################################${NC}" 
-    echo 
-    echo -e "${GREEN}## ${YELLOW}Setup: (re)Enable Firewall...${NC}"
-    echo 
-    sudo systemctl start ufw && sudo systemctl status ufw
-    echo "y" | sudo ufw enable
-    #sudo ufw enable
-    sudo ufw status verbose
-    sleep 2s
-}
-
 
 
 FUNC_CERTBOT(){
@@ -309,25 +288,25 @@ FUNC_CERTBOT(){
     # Install Let's Encrypt Certbot
     sudo apt install certbot python3-certbot-nginx -y
 
-    # Prompt for user email if not provided as a variable
-    if [ -z "$CERT_EMAIL" ]; then
-        echo
-        read -p "Enter your email address for certbot updates: " CERT_EMAIL
-        sed -i "s/^CERT_EMAIL=.*/CERT_EMAIL=\"$CERT_EMAIL\"/" $SCRIPT_DIR/xahl_node.vars
-        echo
-    fi
+    echo -e "${YELLOW}$USER_DOMAINS${NC}"
+
+    IFS=',' read -ra DOMAINS_ARRAY <<< "$USER_DOMAINS"
+    A_RECORD="${DOMAINS_ARRAY[0]}"
+    CNAME_RECORD1="${DOMAINS_ARRAY[1]}"
+    CNAME_RECORD2="${DOMAINS_ARRAY[2]}" 
+
+    # Start Nginx and enable it to start at boot
+    #sudo systemctl start nginx
+    #sudo systemctl enable nginx
 
     # Request and install a Let's Encrypt SSL/TLS certificate for Nginx
-    echo -e "${GREEN}## ${YELLOW}Setup: Request and install a Lets Encrypt SSL/TLS certificate for domain: ${BYELLOW} $USER_DOMAIN${NC}"
-    sudo certbot --nginx  -m "$CERT_EMAIL" -n --agree-tos -d "$USER_DOMAIN"
+    sudo certbot --nginx  -m "$CERT_EMAIL" -n --agree-tos -d "$USER_DOMAINS"
 
     echo
     echo -e "${GREEN}#########################################################################${NC}"
     sleep 4s
 
 }
-
-
 
 
 FUNC_LOGROTATE(){
@@ -338,35 +317,13 @@ FUNC_LOGROTATE(){
 
     USER_ID=$(getent passwd $EUID | cut -d: -f1)
 
-
-    # Prompt for Chain if not provided as a variable
-    if [ -z "$VARVAL_CHAIN_NAME" ]; then
-
-        while true; do
-         read -p "Enter which chain your node is deployed on (e.g. mainnet or testnet): " _input
-
-            case $_input in
-                testnet )
-                    VARVAL_CHAIN_NAME="testnet"
-                    break
-                    ;;
-                mainnet )
-                    VARVAL_CHAIN_NAME="mainnet"
-                    break
-                    ;;
-                * ) echo "Please answer a valid option.";;
-            esac
-        done
-
-    fi
-
     TMP_FILE02=$(mktemp)
     cat <<EOF > $TMP_FILE02
 /opt/xahaud/log/*.log
         {
             su $USER_ID $USER_ID
             size 100M
-            rotate 50
+            rotate 10
             copytruncate
             daily
             missingok
@@ -405,65 +362,50 @@ FUNC_ALLOWLIST_CHECK(){
     fi
     #dockers IP
     #DCKR_HOST_IP=$(sudo docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $VARVAL_CHAIN_NAME_xinfinnetwork_1)
-    LOCAL_IP=$(hostname -I | awk '{print $1}')
-    if [ -z "$LOCAL_IP" ]; then
-        LOCAL_IP="127.0.0.1"
-    fi
 
-    echo "Adding default IPs..."
+    echo "Adding default IPs to both rpc and wss files..."
     echo
     
-    if [ -f "$SCRIPT_DIR/nginx_allowlist.conf" ]; then
-        echo -e "The 'nginx_allowlist.conf' file already exsits at this location, no default changes..."
+    if [ -f "$SCRIPT_DIR/$NGINX_RPC_ALLOWLIST" ]; then
+        echo -e "The `$NGINX_RPC_ALLOWLIST` file already exsits at this location, no default changes..."
     else
-        echo "allow $SRC_IP; # Detected IP of the SSH session" >> $SCRIPT_DIR/nginx_allowlist.conf
+        echo "allow $SRC_IP; # Detected IP of the SSH session" >> $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
         echo -e "added IP $SRC_IP; # Detected IP of the SSH session"
       
-        echo "allow $LOCAL_IP; # Local IP of server" >> $SCRIPT_DIR/nginx_allowlist.conf
-        echo -e "added IP $LOCAL_IP; # Local IP of the server"
+        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST
+        echo -e "added IP $NODE_IP; # ExternalIP of the Node itself"
+    fi
 
-        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> $SCRIPT_DIR/nginx_allowlist.conf
+    if [ -f "$SCRIPT_DIR/$NGINX_WSS_ALLOWLIST" ]; then
+        echo -e "The `$NGINX_WSS_ALLOWLIST` file already exsits at this location, no default changes..."
+    else
+        echo "allow $SRC_IP; # Detected IP of the SSH session" >> $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
+        echo -e "added IP $SRC_IP; # Detected IP of the SSH session"
+
+        echo "allow $NODE_IP; # ExternalIP of the Node itself" >> $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST
         echo -e "added IP $NODE_IP; # ExternalIP of the Node itself"
     fi
 
     echo
     echo
-    echo -e "${BLUE}Add additional IPs to the Allowlist, or press enter to skip... ${NC}"
-    echo
-    while true; do
-        read -p "Enter an additional IP address here (one at a time, for example 10.0.0.20): " user_ip
-
-        # Validate the input using regex (IPv4 format)
-        if [[ $user_ip =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
-            echo -e "${GREEN}IP address: ${YELLOW}$user_ip added to Allow list. ${NC}"
-            echo -e "allow $user_ip;" >> $SCRIPT_DIR/nginx_allowlist.conf
-        else
-            if [ -z "$user_ip" ]; then
-                break
-            else
-                echo -e "${RED}Invalid IP address. Please try again. ${NC}"
-            fi
-        fi
-    done
+    echo -e "${BLUE}ATTENTION! You now have two files in $SCRIPT_DIR called $NGINX_RPC_ALLOWLIST and $NGINX_WSS_ALLOWLIST.${NC}"
+    echo -e
+    echo -e "Now edit the $NGINX_WSS_ALLOWLIST and ADD EACH IP address of your systems that want to access your websockets."
+    echo -e "You can ignore $NGINX_RPC_ALLOWLIST for now, that is in place for potential future use."
+    echo -e 
     sleep 2s
 }
 
 
 FUNC_INSTALL_LANDINGPAGE(){
-    echo
+    echo -e
     echo -e "${GREEN}#########################################################################${NC}"
-    echo 
+    echo -e
     echo -e "${GREEN}## ${YELLOW}Setup: Installing Landing page... ${NC}"
-    echo
-
-    if [ -z "$INSTALL_LANDINGPAGE" ]; then
-        read -p "Do you want to (re)install the landng webpage?: true or false?" INSTALL_LANDINGPAGE
-        sed -i "s/^INSTALL_LANDINGPAGE=.*/INSTALL_LANDINGPAGE=\"$INSTALL_LANDINGPAGE\"/" $SCRIPT_DIR/xahl_node.vars
-    fi
-    if [ "$INSTALL_LANDINGPAGE" == "true" ]; then
+    echo -e
         
-        sudo mkdir -p /home/www
-        echo "Created /home/www directory for webfiles, and re-installing webpage"
+    sudo mkdir -p /home/www
+    echo -e "Created /home/www directory for webfiles, and re-installing webpage."
 
         TMP_FILE03=$(mktemp)
         cat <<EOF > $TMP_FILE03
@@ -531,7 +473,7 @@ FUNC_INSTALL_LANDINGPAGE(){
 
     <script>
         const dataToSend = {"method":"server_info"};
-        fetch('https://$USER_DOMAIN', {
+        fetch('https://$A_RECORD', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -620,7 +562,6 @@ h1 {
     <div class="container">
         <h1>Server Info</h1>
         <p><span style="color: red;">THIS SERVER IS BLOCKING YOUR IP</span></p>
-        <p>Contact Email: $TOML_EMAIL</p>
         <p>YourIP: <span id="realip"></p>
         <p>X-Real-IP: <span id="xrealip"></p>
         <p>-</p>
@@ -636,7 +577,7 @@ h1 {
 
     <script>
         const dataToSend = {"method":"server_info"};
-        fetch('https://$USER_DOMAIN', {
+        fetch('https://$A_RECORD', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -666,62 +607,8 @@ h1 {
 </body>
 </html>
 EOF
-sudo sh -c "cat $TMP_FILE04 > /home/www/error/custom_403.html"
-    else
-        echo -e "${GREEN}## ${YELLOW}Setup: Skipped re-installing Landng webpage install, due to vars file config... ${NC}"
-        echo
-        echo
-    fi
-
-    if [ -z "$INSTALL_TOML" ]; then
-        read -p "Do you want to (re)install the default xahau.toml file?: true or false?" INSTALL_TOML
-        sed -i "s/^INSTALL_TOML=.*/INSTALL_TOML=\"$INSTALL_TOML\"/" $SCRIPT_DIR/xahl_node.vars
-    fi
-    if [ "$INSTALL_TOML" == "true" ]; then
-
-        # Prompt for user email if not provided as a variable
-        if [ -z "$TOML_EMAIL" ]; then
-            echo
-            read -p "Enter your email address for the PUBLIC .toml file: " TOML_EMAIL
-            sed -i "s/^TOML_EMAIL=.*/TOML_EMAIL=\"$TOML_EMAIL\"/" $SCRIPT_DIR/xahl_node.vars
-            echo
-        fi
-        
-        sudo mkdir -p /home/www/.well-known
-        echo "Created /home/www/well-known directory for .toml file, and re-creating default .toml file"
-        TMP_FILE05=$(mktemp)
-        cat <<EOF > $TMP_FILE05
-[[METADATA]]
-created = $FDATE
-modified = $FDATE
-
-[[PRINCIPALS]]
-name = "evernode"
-email = "$TOML_EMAIL"
-discord = ""
-
-[[ORGANIZATION]]
-website = "https://$USER_DOMAIN"
-
-[[SERVERS]]
-domain = "https://$USER_DOMAIN"
-install = "Created by go140point6 & gadget78 (fork of original work by inv4fee2020 for XDC Network.)"
-
-[[STATUS]]
-NETWORK = "$VARVAL_CHAIN_NAME"
-NODESIZE = "$XAHAU_NODE_SIZE"
-
-[[AMENDMENTS]]
-
-# End of file
-EOF
-sudo sh -c "cat $TMP_FILE05 > /home/www/.well-known/xahau.toml"
-
-    else
-        echo -e "${GREEN}## ${YELLOW}Setup: Skipped re-installing default xahau.toml file, due to vars file config... ${NC}"
-        echo
-        echo
-    fi
+    sudo sh -c "cat $TMP_FILE04 > /home/www/error/custom_403.html"
+    
     echo
     sleep 2s
 }
@@ -739,31 +626,11 @@ FUNC_NODE_DEPLOY(){
     sleep 3s
 
     # installs updates, and default packages listed in vars file
+    FUNC_CHECK_VARS;
+    FUNC_EXIT;
+
     FUNC_PKG_CHECK;
     #FUNC_EXIT;
-
-    #if [ "$VARVAL_CHAIN_NAME" != "mainnet" ] && [ "$VARVAL_CHAIN_NAME" != "testnet" ] && [ "$VARVAL_CHAIN_NAME" != "logrotate" ]; then
-    if [ "$VARVAL_CHAIN_NAME" != "mainnet" ] && [ "$VARVAL_CHAIN_NAME" != "testnet" ]; then
-        echo -e "${RED}VARVAL_CHAIN_NAME not set in $SCRIPT_DIR/xahl_node.vars"
-        echo "Please choose an option:"
-        echo "1. Mainnet = configures and deploys/updates xahau node for Mainnet"
-        echo "2. Testnet = configures and deploys/updates xahau node for Testnet"
-        read -p "Enter your choice [1-2]: " choice
-        
-        case $choice in
-            1) 
-                VARVAL_CHAIN_NAME="mainnet"
-                ;;
-            2) 
-                VARVAL_CHAIN_NAME="testnet"
-                ;;
-            *) 
-                echo "Invalid option. Exiting."
-                FUNC_EXIT
-                ;;
-        esac
-        sed -i "s/^VARVAL_CHAIN_NAME=.*/VARVAL_CHAIN_NAME=\"$VARVAL_CHAIN_NAME\"/" $SCRIPT_DIR/xahl_node.vars
-    fi
 
     if [ "$VARVAL_CHAIN_NAME" == "mainnet" ]; then
         echo -e "${GREEN}### Configuring node for ${BYELLOW}$_OPTION${GREEN}... ${NC}"
@@ -802,42 +669,8 @@ FUNC_NODE_DEPLOY(){
         echo -e "${GREEN}## NGINX is already installed. Skipping ${NC}"
     fi
 
-
-
-    # Check if UFW is installed
-    echo
-    echo -e "${GREEN}#########################################################################${NC}"
-    echo 
-    echo -e "${GREEN}## ${YELLOW}Setup: Checking UFW... ${NC}"
-    echo
-    sudo ufw version
-    if [ $? = 0 ]; then
-        echo -e "${GREEN}UFW is ALREADY installed ${NC}"
-        echo
-        # Setup UFW
-        FUNC_SETUP_UFW_PORTS;
-        FUNC_ENABLE_UFW;
-        #FUNC_EXIT;
-    else
-        echo
-        echo -e "${GREEN}## ${YELLOW}UFW is not installed, checking config option... ${NC}"
-        echo
-        
-        if [ -z "$INSTALL_UFW" ]; then
-            read -p "Do you want to install UFW (Uncomplicated Firewall) ? enter true or false:" INSTALL_UFW
-            sed -i "s/^INSTALL_UFW=.*/INSTALL_UFW=\"$INSTALL_UFW\"/" $SCRIPT_DIR/xahl_node.vars
-        fi
-        if [ "$INSTALL_UFW" == "true" ]; then
-            echo
-            echo -e "${GREEN}## ${YELLOW}Setup: Installing UFW... ${NC}"
-            echo
-            sudo apt install ufw
-            FUNC_SETUP_UFW_PORTS;
-            FUNC_ENABLE_UFW;
-            #FUNC_EXIT;
-        fi
-    fi
-    
+    # Configure UFW if present
+    FUNC_SETUP_UFW;
 
     # Xahau Node setup
     FUNC_CLONE_NODE_SETUP;
@@ -851,36 +684,20 @@ FUNC_NODE_DEPLOY(){
     FUNC_ALLOWLIST_CHECK;
     #FUNC_EXIT;
 
-    # Prompt for user domain if not provided as a variable
-    if [ -z "$USER_DOMAIN" ]; then
-        read -p "Enter your servers domain (e.g. EXAMPLE.com or a subdomain like xahl.EXAMPLE.com ): " USER_DOMAIN
-        sed -i "s/^USER_DOMAIN=.*/USER_DOMAIN=\"$USER_DOMAIN\"/" $SCRIPT_DIR/xahl_node.vars
-    fi
-
-    # check/install CERTBOT (for SSL)
+    # Install CERTBOT (for SSL)
     echo
     echo -e "${GREEN}#########################################################################${NC}"
     echo 
-    echo -e "${GREEN}## ${YELLOW}Setup: Checking CERTBOT options... ${NC}"
+    echo -e "${GREEN}## ${YELLOW}Setup: Install and configure CERTBOT... ${NC}"
     echo
 
-    if [ -z "$INSTALL_CERTBOT_SSL" ]; then
-        read -p "Do you want to use install CERTBOT and use SSL? : true or false?" INSTALL_CERTBOT_SSL
-        sed -i "s/^INSTALL_CERTBOT_SSL=.*/INSTALL_CERTBOT_SSL=\"$INSTALL_CERTBOT_SSL\"/" $SCRIPT_DIR/xahl_node.vars
-    fi
-    if [ "$INSTALL_CERTBOT_SSL" == "true" ]; then
-        FUNC_CERTBOT;
-        #FUNC_EXIT;
-    else
-        echo -e "${GREEN}## ${YELLOW}Setup: Skipping CERTBOT install... ${NC}"
-        echo
-        echo
-    fi
+    FUNC_CERTBOT;
+    #FUNC_EXIT;
 
     #setup and install the landing page,
     FUNC_INSTALL_LANDINGPAGE;
 
-    # Create a new Nginx configuration file with the user-provided domain....
+    # Create a new Nginx configuration file with the user-provided variables....
     echo
     echo -e "${GREEN}#########################################################################${NC}"
     echo
@@ -895,22 +712,21 @@ FUNC_NODE_DEPLOY(){
         sudo rm -f $NGX_CONF_AVAIL/default
     fi
     
-    if [ "$INSTALL_CERTBOT_SSL" == "true" ]; then
-        TMP_FILE06=$(mktemp)
-        cat <<EOF > $TMP_FILE06
+    TMP_FILE06=$(mktemp)
+    cat <<EOF > $TMP_FILE06
 server {
     listen 80;
-    server_name $USER_DOMAIN;
+    server_name $A_RECORD $CNAME_RECORD1 $CNAME_RECORD2;
     return 301 https://\$host\$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name $USER_DOMAIN;
+    server_name $CNAME_RECORD1;
 
     # SSL certificate paths
-    ssl_certificate /etc/letsencrypt/live/$USER_DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$USER_DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$$A_RECORD/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$$A_RECORD/privkey.pem;
 
     # Other SSL settings
     ssl_protocols TLSv1.3 TLSv1.2;
@@ -935,57 +751,47 @@ server {
     
     location / {
         try_files \$uri \$uri/ =404;
-        include $SCRIPT_DIR/$NGINX_ALLOWLIST_FILE;
+        include $SCRIPT_DIR/$NGINX_RPC_ALLOWLIST;
         deny all;
 
-        # These three are critical to getting websockets to work
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade \$http_upgrade;
-        proxy_set_header Connection "upgrade";
-        if (\$http_upgrade = "websocket") {
-                add_header X-Upstream \$upstream_addr;
-                proxy_pass  http://localhost:$VARVAL_CHAIN_WSS;
-        }
-        if (\$request_method = POST) {
-                proxy_pass http://localhost:$VARVAL_CHAIN_RPC;
-        }
-
-        root /home/www;
+        proxy_pass http://localhost:$VARVAL_CHAIN_RPC;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_cache off;
+        proxy_buffering off;
+        tcp_nopush  on;
+        tcp_nodelay on;
     }
 
-    location /.well-known/xahau.toml {
-        allow all;
-        try_files \$uri \$uri/ =403;
-        root /home/www;
-    }
+    # Additional server configurations
+
+    # Set Content Security Policy (CSP) header
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline';";
 
     # Enable XSS protection
     add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
-
 }
-EOF
-sudo sh -c "cat $TMP_FILE06 > $NGX_CONF_AVAIL/xahau"
 
-    else
-        TMP_FILE06=$(mktemp)
-        cat <<EOF > $TMP_FILE06
+
 server {
-    listen 80;
-    server_name $USER_DOMAIN;
+    listen 443 ssl http2;
+    server_name $CNAME_RECORD2;
 
     # SSL certificate paths
-    #ssl_certificate /etc/letsencrypt/live/$USER_DOMAIN/fullchain.pem;
-    #ssl_certificate_key /etc/letsencrypt/live/$USER_DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$$A_RECORD/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$$A_RECORD/privkey.pem;
 
     # Other SSL settings
-    #ssl_protocols TLSv1.3 TLSv1.2;
-    #ssl_ciphers 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-RSA-AES256-GCM-SHA384';
-    #ssl_prefer_server_ciphers off;
-    #ssl_session_timeout 1d;
-    #ssl_session_cache shared:SSL:10m;
-    #ssl_session_tickets off;
+    ssl_protocols TLSv1.3 TLSv1.2;
+    ssl_ciphers 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-RSA-AES256-GCM-SHA384';
+    ssl_prefer_server_ciphers off;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
 
     # Additional SSL settings, including HSTS
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
@@ -1002,39 +808,37 @@ server {
     
     location / {
         try_files \$uri \$uri/ =404;
-        include $SCRIPT_DIR/$NGINX_ALLOWLIST_FILE;
+        include $SCRIPT_DIR/$NGINX_WSS_ALLOWLIST;
         deny all;
+
+        proxy_pass http://localhost:$VARVAL_CHAIN_WSS;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_cache off;
+        proxy_buffering off;
+        tcp_nopush  on;
+        tcp_nodelay on;
 
         # These three are critical to getting websockets to work
         proxy_http_version 1.1;
-        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        if (\$http_upgrade = "websocket") {
-                add_header X-Upstream \$upstream_addr;
-                proxy_pass  http://localhost:$VARVAL_CHAIN_WSS;
-        }
-        if (\$request_method = POST) {
-                proxy_pass http://localhost:$VARVAL_CHAIN_RPC;
-        }
-
-        root /home/www;
     }
 
-    location /.well-known/xahau.toml {
-        allow all;
-        try_files \$uri \$uri/ =403;
-        root /home/www;
-    }
+    # Additional server configurations
+
+    # Set Content Security Policy (CSP) header
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline';";
 
     # Enable XSS protection
     add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
-
 }
 EOF
-sudo sh -c "cat $TMP_FILE06 > $NGX_CONF_AVAIL/xahau"
-    fi
+    sudo sh -c "cat $TMP_FILE06 > $NGX_CONF_AVAIL/xahau"
 
     #check if symbolic link file exists in sites-enabled, if not create it
     if [ ! -f $NGX_CONF_ENABLED/xahau ]; then
@@ -1054,35 +858,22 @@ sudo sh -c "cat $TMP_FILE06 > $NGX_CONF_AVAIL/xahau"
     fi
     sudo systemctl enable nginx.service
 
-    echo
+    echo -e
     echo -e "${GREEN}#########################################################################${NC}"
-    echo
-    echo -e "${GREEN}## Setup: Created and enabled a new Nginx configuration files ${NC}"
-    echo
-    echo -e "Nginx is now installed and running at Local IP: ${YELLOW}$LOCAL_IP${NC} listening for the domain: ${YELLOW}$USER_DOMAIN.${NC}"
-    echo
-    echo -e "${GREEN}#########################################################################${NC}"
-    echo
-
-    # if $ORIGINAL_USER_ID; then 
-    #   echo -e "${GREEN}## ${YELLOW}Setup: just applying corrective ownership... ${NC}"
-    #   sudo chown -R $ORIGINAL_USER_ID:users $SCRIPT_DIR
-    # fi
-
     echo -e "Your Xahau Node should now be up and running."
-    echo
-    echo -e "Locally: Websocket ${BYELLOW}ws://$LOCAL_IP${NC} or RPC/API ${BYELLOW}http://$LOCAL_IP ${NC}"
-    echo
-    echo -e "Externally: Websocket ${BYELLOW}wss://$USER_DOMAIN${NC} or RPC/API ${BYELLOW}https://$USER_DOMAIN ${NC}"
-    echo
-    echo -e "Use file ${BYELLOW}'$SCRIPT_DIR/$NGINX_ALLOWLIST_FILE'${NC} to add/remove IP addresses that access your node."
-    echo -e "Once file is edited and saved, TEST it with ${BYELLOW}'sudo nginx -t'${NC} before running the command ${BYELLOW}'sudo nginx -s reload'${NC} to apply new settings."
-    echo
-    echo -e "$You can use command ${BYELLOW}xahaud server_info${NC} to get info direct from the xahaud server"
-    echo
+    echo -e
+    echo -e "Externally: Websocket ${BYELLOW}wss://$CNAME2${NC} or RPC/API ${BYELLOW}https://$CNAME1${NC}"
+    echo -e
+    echo -e "Use file ${BYELLOW}$SCRIPT_DIR/$NGINX_WSS_ALLOWLIST${NC} to add/remove IP addresses that access your node using websockets."
+    echo -e "Once file is edited and saved, TEST it with ${BYELLOW}'sudo nginx -t'${NC} before running the command ${BYELLOW}'sudo systemctl reload nginx.service'${NC} to apply new settings."
+    echo -e
+    echo -e "Ingore file ${BYELLOW}$SCRIPT_DIR/$NGINX_RPC_ALLOWLIST${NC}. It was generated only as a placeholder for future potential use."
+    echo -e
+    echo -e "Use command ${BYELLOW}xahaud server_info${NC} to get info direct from the xahaud server."
+    echo -e
     echo -e "${GREEN}## ${YELLOW}Setup complete.${NC}"
-    echo
-    echo
+    echo -e
+    echo -e
 
     FUNC_EXIT
 }

--- a/setup.sh
+++ b/setup.sh
@@ -75,11 +75,14 @@ FUNC_CHECK_VARS(){
 
     if [ "$USER_DNS_RECORDS" = "xahl.EXAMPLE.com,rpc.EXAMPLE.com,wss.EXAMPLE.com" ]; then
         ERROR1="USER_DNS_RECORDS appears to be using sample data in xahl_node.vars."
-    elif [ "$CERT_EMAIL" = "yourRealEmailAddress@EXAMPLE.com" ]; then
+    fi
+    if [ "$CERT_EMAIL" = "yourRealEmailAddress@EXAMPLE.com" ]; then
         ERROR2="CERT_EMAIL appears to be using sample data in xahl_node.vars."
-    elif [ "$XAHAU_NODE_SIZE" != "tiny" ] && [ "$XAHAU_NODE_SIZE" != "small" ] && [ "$XAHAU_NODE_SIZE" != "medium" ] && [ "$XAHAU_NODE_SIZE" != "huge" ]; then
+    fi
+    if [ "$XAHAU_NODE_SIZE" != "tiny" ] && [ "$XAHAU_NODE_SIZE" != "small" ] && [ "$XAHAU_NODE_SIZE" != "medium" ] && [ "$XAHAU_NODE_SIZE" != "huge" ]; then
         ERROR3="XAHAU_NODE_SIZE appears to be using some value that is not valid in xahl_node.vars."
-    elif [ "$VARVAL_CHAIN_NAME" != 'mainnet' ] && [ "$VARVAL_CHAIN_NAME" != 'testnet' ]; then
+    fi
+    if [ "$VARVAL_CHAIN_NAME" != 'mainnet' ] && [ "$VARVAL_CHAIN_NAME" != 'testnet' ]; then
         ERROR4="VARVAL_CHAIN_NAME appears to be set incorrectly, valid options are mainnet or testnet ONLY."
     fi
 

--- a/xahl_node.vars
+++ b/xahl_node.vars
@@ -7,7 +7,7 @@
 
 # *** UPDATE WITH YOUR VALUES - A Record 1st, RPC CNAME 2nd, WS CNAME 3rd *** #
 # a comma-separated list of domains, A record followed by CNAME records for RPC & WSS respectively (e.g., server.mydomain.com,rpc.mydomain.com,wss.mydomain.com)
-USER_DOMAINS="xahl.EXAMPLE.com,rpc.EXAMPLE.com,wss.EXAMPLE.com"
+USER_DNS_RECORDS="xahl.EXAMPLE.com,rpc.EXAMPLE.com,wss.EXAMPLE.com"
 
 # Lets Encrypt certbot email address for notification of renewal etc.
 CERT_EMAIL="yourRealEmailAddress@EXAMPLE.com"

--- a/xahl_node.vars
+++ b/xahl_node.vars
@@ -5,33 +5,30 @@
 #    INSTALL_LANDINGPAGE="false" will prevent creation/updating of the landing page (i.e. if you have a custom one).
 #
 
-# *** UPDATE THESE WITH YOUR VALUES *** #
-
-# Enter your servers domain (e.g. "xahl.EXAMPLE.com")
-USER_DOMAIN=""
+# *** UPDATE WITH YOUR VALUES - A Record 1st, RPC CNAME 2nd, WS CNAME 3rd *** #
+# a comma-separated list of domains, A record followed by CNAME records for RPC & WSS respectively (e.g., server.mydomain.com,rpc.mydomain.com,wss.mydomain.com)
+USER_DOMAINS="xahl.EXAMPLE.com,rpc.EXAMPLE.com,wss.EXAMPLE.com"
 
 # Lets Encrypt certbot email address for notification of renewal etc.
-CERT_EMAIL=""
-TOML_EMAIL=""
+CERT_EMAIL="yourRealEmailAddress@EXAMPLE.com"
 
 # variables for node choices, details found here https://github.com/go140point6/xahl-info/blob/main/tune-small-environments.md
-# Size has 3 options tiny/medium/huge;
-# tiny less than 8G-RAM 50GB-HDD, medium 16G-RAM 250GB-HDD, huge 32G+RAM nolimit-HDD  as no limit
+# Size has 4 options tiny/small/medium/huge
+# tiny less than 8G RAM 50G+ Storage, small 8G+ RAM 100G+ Storage, medium 16G+ RAM 250GB+ Storage, huge 32G+ RAM 500G+ Storage.
 XAHAU_NODE_SIZE="tiny"
 
 # variables for size setup
-TINY_LEDGER_HISTORY="512"
-TINY_LEDGER_DELETE="512"
-MEDIUM_LEDGER_HISTORY="2048"
-MEDIUM_LEDGER_DELETE="2048"
+TINY_LEDGER_HISTORY="2048"
+TINY_LEDGER_DELETE="2048"
+SMALL_LEDGER_HISTORY="4096"
+SMALL_LEDGER_DELETE="4096"
+MEDIUM_LEDGER_HISTORY="8192"
+MEDIUM_LEDGER_DELETE="8192"
+HUGE_LEDGER_HISTORY="16384"
+HUGE_LEDGER_DELETE="16384"
 
 # variables for script choices
-INSTALL_UPDATES="true"
 VARVAL_CHAIN_NAME="mainnet"
-INSTALL_UFW="true"
-INSTALL_CERTBOT_SSL="true"
-INSTALL_LANDINGPAGE="true"
-INSTALL_TOML="true"
 
 # -------------------------------------------------------------------------------
 # *** the following variables DO NOT need to be changed ***
@@ -47,7 +44,8 @@ SYS_PACKAGES=(net-tools git curl gpg nano node-ws python3 whois htop mlocate apa
 NGX_CONF_ENABLED="/etc/nginx/sites-enabled"
 NGX_CONF_AVAIL="/etc/nginx/sites-available"
 NGINX_CONF_FILE="/etc/nginx/nginx.conf"
-NGINX_ALLOWLIST_FILE="nginx_allowlist.conf"
+NGINX_RPC_ALLOWLIST="nginx_rpc_allowlist.conf"
+NGINX_WSS_ALLOWLIST="nginx_wss_allowlist.conf"
 
 # MAINNET
 NGX_MAINNET_RPC="6007"


### PR DESCRIPTION
This version is back to the "old method" of using a single host (A) record and two CNAME records. You MUST edit the xahl_nodes.vars file with YOUR values AFTER you create all THREE records in DNS.

[@gadget78](https://github.com/gadget78/xahl-node) is currently hosting the NEW method which uses a single host record and has some advanced status page features. I have decided to stick with my old method as an alternative option. The only major improvement with my script now is that it automatically adds the XAHL self-pruning feature so you don't unexpectedly run out of space. It also splits the allowlist for RPC and WSS in files in the home directory. As time permits, I may go back and introduce gadget's status page and toml features.